### PR TITLE
binary search definitions for massive speedup

### DIFF
--- a/lib/rubrowser/data.rb
+++ b/lib/rubrowser/data.rb
@@ -15,7 +15,7 @@ module Rubrowser
     def parse
       parsers.each(&:parse)
 
-      @definitions ||= parsers.map(&:definitions).reduce(:+).to_a
+      @definitions ||= parsers.map(&:definitions).reduce(:+).sort{|a,b| b<=>a}.to_a
       @relations ||= parsers.map(&:relations).reduce(:+).to_a
 
       mark_circular_dependencies

--- a/lib/rubrowser/parser/definition/base.rb
+++ b/lib/rubrowser/parser/definition/base.rb
@@ -36,6 +36,10 @@ module Rubrowser
           namespace == other.namespace
         end
 
+        def <=>(other)
+          to_s <=> other.to_s
+        end
+
         def to_s
           namespace.join('::')
         end

--- a/lib/rubrowser/parser/relation/base.rb
+++ b/lib/rubrowser/parser/relation/base.rb
@@ -32,7 +32,7 @@ module Rubrowser
 
         def resolve(definitions)
           possibilities.find do |possibility|
-            definitions.any? { |definition| definition == possibility }
+            !!definitions.bsearch { |definition| definition <=> possibility }
           end || possibilities.last
         end
 

--- a/spec/parser/data_spec.rb
+++ b/spec/parser/data_spec.rb
@@ -97,8 +97,6 @@ describe Rubrowser::Data do
   end
 
   context 'When there are circular relations' do
-    let(:non_circular_index) { 2 }
-
     let(:file_path) do
       'spec/parser/fixtures/class_related_to_circular_dependency.rb'
     end
@@ -113,16 +111,16 @@ describe Rubrowser::Data do
     end
 
     it 'does NOT mark non-circular relations near the circular relation' do
-      expect(relations[non_circular_index].circular?).to eq(false)
+      expect(relations[2].circular?).to eq(false)
     end
 
     it 'marks definitions that are circular' do
-      expect(definitions[0].circular?).to eq(true)
+      expect(definitions[2].circular?).to eq(true)
       expect(definitions[1].circular?).to eq(true)
     end
 
     it 'does NOT mark non-circular definition near the circular definition' do
-      expect(definitions[non_circular_index].circular?).to eq(false)
+      expect(definitions[0].circular?).to eq(false)
     end
   end
 end


### PR DESCRIPTION
On our massive rails app at AngelList we have 12k ruby files. Running rubrowser took a looong time. I looked into what it was doing when running, and I realized most of the time was spent in == function due to a O(n^2) part of the algorithm that was finding matches of namespaces. Ruby 2 introduced bsearch on enumerable which lets us do the same work with O(n*log n). The only catch is the definitions set needs to be sorted.

The rspec test had to change because it was assuming a certain order of the definitions.

Before patch
771.29s user 0.63s system 100% cpu 12:51.45 total

After patch
60.03s user 0.57s system 99% cpu 1:00.61 total