### PR TITLE
Capture constants defined in a namespace in definitions

### DIFF
--- a/spec/parser/data_spec.rb
+++ b/spec/parser/data_spec.rb
@@ -123,4 +123,20 @@ describe Rubrowser::Data do
       expect(definitions[0].circular?).to eq(false)
     end
   end
+
+
+  context 'Class with a constant' do
+    let(:file_path) do
+      'spec/parser/fixtures/class_with_constant.rb'
+    end
+
+    let(:file) { Rubrowser::Data.new([file_path]) }
+    let(:definitions) { file.definitions }
+    let(:relations) { file.relations }
+
+    it 'defines the constant as a definition' do
+      expect(definitions.size).to be(3)
+      expect(definitions[0].to_s).to be("A::B::C")
+    end
+  end
 end

--- a/spec/parser/fixtures/class_with_constant.rb
+++ b/spec/parser/fixtures/class_with_constant.rb
@@ -1,0 +1,9 @@
+module A
+  class B
+    C = 5
+
+    def c
+      C
+    end
+  end
+end


### PR DESCRIPTION
In master modules and classes found in ruby files appear in definitions, but constants created in those blocks do not appear in definitions but only appear when referenced in relations. This makes it impossible to know that a constant that is used in a ruby file is defined in that same file, so it is not an external reference.

This pr captures the unscoped constants that appear in ruby modules and classes. https://github.com/whitequark/parser/blob/master/doc/AST_FORMAT.md#unscoped-constant-1 you can then identify relations to constants defined in the namespace.

These appear as nodes with casgn type with 3 children `[nil, const symbol, value node]`. It looks like there are other types of constant assignments exist where the first array element would be non nil, but I don't have any examples of them in our code base so not sure what to do there.