### PR TITLE
Fix parsing for fully qualified constants

### DIFF
--- a/lib/rubrowser/parser/definition/base.rb
+++ b/lib/rubrowser/parser/definition/base.rb
@@ -5,7 +5,7 @@ module Rubrowser
         attr_reader :namespace, :file, :line, :lines
 
         def initialize(namespace, file: nil, line: nil, lines: 0)
-          @namespace = Array(namespace)
+          @namespace = Array(namespace).compact
           @file = file
           @line = line
           @lines = lines

--- a/spec/parser/data_spec.rb
+++ b/spec/parser/data_spec.rb
@@ -123,4 +123,33 @@ describe Rubrowser::Data do
       expect(definitions[0].circular?).to eq(false)
     end
   end
+
+  context 'Fully qualified constants' do
+    let(:file_path) do
+      'spec/parser/fixtures/fully_qualified_constants.rb'
+    end
+
+    let(:file) { Rubrowser::Data.new([file_path]) }
+    let(:definitions) { file.definitions }
+    let(:relations) { file.relations }
+
+    it 'marks relations that are circular' do
+      expect(relations[1].circular?).to eq(true)
+      expect(relations[2].circular?).to eq(true)
+    end
+
+    it 'does NOT mark non-circular relations near the circular relation' do
+      expect(relations[0].circular?).to eq(false)
+      expect(relations[3].circular?).to eq(false)
+    end
+
+    it 'does NOT mark non-circular definition near the circular definition' do
+      expect(definitions[0].circular?).to eq(false)
+      expect(definitions[1].circular?).to eq(false)
+    end
+
+    it 'marks definitions that are circular' do
+      expect(definitions[2].circular?).to eq(true)
+    end
+  end
 end

--- a/spec/parser/fixtures/fully_qualified_constants.rb
+++ b/spec/parser/fixtures/fully_qualified_constants.rb
@@ -1,0 +1,30 @@
+module ::Quz
+end
+
+class ::A
+  include ::Quz
+
+  def initialize
+    ::B.do
+  end
+
+  def self.do; end
+end
+
+class ::B
+  def initialize
+    ::A.do
+  end
+
+  def self.do; end
+end
+
+class ::C
+  include ::Quz
+
+  def initialize
+    ::A.do
+  end
+
+  def self.do; end
+end


### PR DESCRIPTION
Hi there!

In my application, I'm using fully qualified constant names, like `class ::A::B::C` or `::X::Y.new`.
I noticed that rubrower doesn't build relations for the classes and modules defined this way. 
The solution is pretty simple, we need to filter out the "ephemeral" root namespace from the namespace list when building a Definition, so `[nil, :A]` becomes `[:A]`.


